### PR TITLE
Tell users that they can specify several addresse

### DIFF
--- a/README
+++ b/README
@@ -13,6 +13,8 @@ Installing
 
 (Don't forget to add your email address)
 
+If you have several accounts configured on your mutt, you can putt them all on your mailcap entry, i.e `-e user1@domain1.tld,user2@domain2,tld` the script will answer using the invited address
+
 OSX Users
 ---------
 


### PR DESCRIPTION
Hello again (that one is the last),

Another (almost) issue I had was that I use several email addresses on my mutt, but the Readme does not tell how to handle that. Looking at the source, I was pleased to see that we can specify several emails with `-e user1@domain1.tld,user2@domain2.tld` and the script already handles that perfectly.

So as I was already gonna do two PRs, I guessed that I could do one more for updating the Readme so everybody can see how awesome this script is !

David